### PR TITLE
Added support for passReqToCallback option

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -29,6 +29,8 @@ build/Release
 # https://www.npmjs.org/doc/misc/npm-faq.html#should-i-check-my-node_modules-folder-into-git
 node_modules
 
+# IDE metadata directory
+.idea/
 
 ### Vim ###
 [._]*.s[a-w][a-z]

--- a/README.md
+++ b/README.md
@@ -17,7 +17,8 @@ Create the strategy with an options object and a "verify request" callback.
 
 ### Options
 
- `headers` - required. Array of HTTP header names to extract. A request has to contain all of these headers to be authenticated.
+* `headers` - required. Array of HTTP header names to extract. A request has to contain all of these headers to be authenticated.
+* `passReqToCallback` - optional. Causes the request object to be supplied to the verify callback as the first parameter.
 
 The verify callback decides whether to authenticate each request. It called with the extracted header names/values and a [passport.js `done` callback](http://passportjs.org/guide/configure/).
 
@@ -31,6 +32,27 @@ var options =  {
 }
 
 passport.use(new Strategy(options, function(requestHeaders, done) {
+  var user = null;
+  var userDn = requestHeaders.TLS_CLIENT_DN;
+
+  // Authentication logic here!
+  if(userDn === 'CN=test-cn') {
+    user = { name: 'Test User' }
+  }
+
+  done(null, user);
+}));
+````
+
+The verify callback can be supplied with the `request` object by setting the `passReqToCallback` option to `true`, and changing callback arguments accordingly.
+
+````javascript
+var options =  {
+  headers: ['TLS_CLIENT_DN'],
+  passReqToCallback: true
+}
+
+passport.use(new Strategy(options, function(req, requestHeaders, done) {
   var user = null;
   var userDn = requestHeaders.TLS_CLIENT_DN;
 

--- a/package.json
+++ b/package.json
@@ -33,13 +33,13 @@
   },
   "homepage": "https://github.com/ripjar/passport-trusted-header",
   "dependencies": {
-    "passport-strategy": "1.*"
+    "passport-strategy": "^1.0.0"
   },
   "devDependencies": {
-    "passport": "^0.2.0",
-    "chai": "^1.9.1",
-    "colors": "^0.6.2",
-    "express": "3.*",
-    "mocha": "^1.20.1"
+    "chai": "^3.3.0",
+    "colors": "^1.1.2",
+    "express": "^4.13.3",
+    "mocha": "^2.3.3",
+    "passport": "^0.3.0"
   }
 }

--- a/test/strategy-test.js
+++ b/test/strategy-test.js
@@ -116,6 +116,28 @@ describe("trusted headers strategy", function() {
       ok.should.eq(true);
     });
 
+    it("should pass the request object to the verify callback when directed", function () {
+      var passedReq;
+
+      strategy = new Strategy({
+        passReqToCallback: true,
+        headers: options.headers
+      }, function (req, cert, done) {
+        passedReq = req;
+        done(null, {});
+      });
+
+      strategy.fail = fail;
+      strategy.success = success;
+      req = helpers.dummyReq(null, null, headers);
+
+      strategy.authenticate(req);
+
+      failed.should.eq(false);
+      succeeded.should.eq(true);
+      passedReq.should.eq(req);
+    });
+
   });
 
 });


### PR DESCRIPTION
I added support for the `passReqToCallback` option that is fairly prevalent in passport strategies. As in most of the other implementations, I broke out your `verified` function into its own definition. Most of them just use a function statement, but to follow your lint/hint settings, I used an assigned (but named) function expression instead.

I couldn't get your devdeps to install properly (probably issues with the old versions), so I updated those dependencies. The tests still ran, so hopefully all is well there. I added a test to verify that this works.
