### PR TITLE
added case insensitive header handling

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -32,8 +32,8 @@ exports.Strategy.prototype.authenticate = function authenticate(req) {
       extractedHeaders = {};
 
   var foundHeaders = this._headers.every(function(h) {
-    if(req.headers[h]) {
-      extractedHeaders[h] = req.headers[h];
+    if(req.headers[h.toLowerCase()]) {
+      extractedHeaders[h] = req.headers[h.toLowerCase()];
       return true;
     }
   });

--- a/test/strategy-test.js
+++ b/test/strategy-test.js
@@ -66,6 +66,17 @@ describe("trusted headers strategy", function() {
       failed.should.eq(true);
     });
 
+    it("should match headers regardless of case", function() {
+      strategy = new Strategy({ headers: ["H1", "h2"] }, function(cert) {
+        passedToVerify = cert;
+      });
+      
+      req = helpers.dummyReq(null, null, headers);
+
+      strategy.authenticate(req);
+      passedToVerify.should.eql({ H1: headers.h1, h2: headers.h2 });
+    });
+
     it("should pass extracted headers to the verify callback", function() {
       req = helpers.dummyReq(null, null, headers);
 


### PR DESCRIPTION
I ran into some issues using this library when specifying uppercase headers. Node JS turns all header names in the req.headers object into lowercase. This change lowercases the header names specified in the options when trying to get the values from req.headers. in the callback function the headers are mapped to the keys as specified in options so if you specify uppercase header names here they will be uppercase in requestHeaders